### PR TITLE
Complete export based on metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+Dependencies/

--- a/gdquest_art_tools/Config.py
+++ b/gdquest_art_tools/Config.py
@@ -1,8 +1,10 @@
 import re
 
-
-config = {'outDir': 'export',
-          'rootPat': r'^root',
-          'supportedExtensions': ['png', 'jpg', 'jpeg']}
+config = {
+    'outDir': 'export',
+    'rootPat': r'^root',
+    'sym': r'\W'
+}  # yapf: disable
 config['rootPat'] = re.compile(config['rootPat'])
+config['sym'] = re.compile(config['sym'])
 

--- a/gdquest_art_tools/GDquestArtTools.py
+++ b/gdquest_art_tools/GDquestArtTools.py
@@ -8,7 +8,7 @@ import os
 import os.path as osp
 from functools import partial
 from krita import DockWidget, DockWidgetFactory, DockWidgetFactoryBase, Krita
-from PyQt5.QtWidgets import QPushButton, QLabel, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QPushButton, QLabel, QLineEdit, QHBoxLayout, QVBoxLayout, QWidget
 
 from .Infrastructure import WNode
 from .Utils import kickstart, flip
@@ -41,6 +41,10 @@ def exportSelectedLayers():
     kickstart(it)
 
 
+def renameLayers():
+    print('test')
+
+
 class GameArtTools(DockWidget):
     TITLE = 'GDquest Art Tools'
 
@@ -54,18 +58,33 @@ class GameArtTools(DockWidget):
         uiContainer = QWidget(self)
 
         exportLabel = QLabel('Export')
-        exportAllLayersButton = QPushButton('All Layers', uiContainer)
-        exportAllLayersButton.released.connect(exportAllLayers)
+        exportAllLayersButton = QPushButton('All Layers')
+        exportSelectedLayersButton = QPushButton('Selected Layers')
+        renameLabel = QLabel('Rename')
+        renameLineEdit = QLineEdit()
+        renameButton = QPushButton('Rename')
 
-        exportSelectedLayersButton = QPushButton('Selected Layers', uiContainer)
-        exportSelectedLayersButton.released.connect(exportSelectedLayers)
+        vboxlayout = QVBoxLayout()
+        vboxlayout.addWidget(exportLabel)
+        vboxlayout.addWidget(exportAllLayersButton)
+        vboxlayout.addWidget(exportSelectedLayersButton)
+        vboxlayout.addWidget(renameLabel)
+        vboxlayout.addWidget(renameLineEdit)
 
-        uiContainer.setLayout(QVBoxLayout())
-        uiContainer.layout().addWidget(exportLabel)
-        uiContainer.layout().addWidget(exportAllLayersButton)
-        uiContainer.layout().addWidget(exportSelectedLayersButton)
+        hboxlayout = QHBoxLayout()
+        hboxlayout.addStretch()
+        hboxlayout.addWidget(renameButton)
 
+        vboxlayout.addLayout(hboxlayout)
+        vboxlayout.addStretch()
+
+        uiContainer.setLayout(vboxlayout)
         self.setWidget(uiContainer)
+
+        exportSelectedLayersButton.released.connect(exportSelectedLayers)
+        exportAllLayersButton.released.connect(exportAllLayers)
+        renameLineEdit.returnPressed.connect(renameLayers)
+        renameButton.released.connect(renameLayers)
 
     def canvasChanged(self, canvas):
         pass

--- a/gdquest_art_tools/Infrastructure.py
+++ b/gdquest_art_tools/Infrastructure.py
@@ -4,7 +4,7 @@ import os.path as osp
 from PIL import Image, ImageOps
 
 from .Utils import kickstart
-from .Utils.Export import sanitize, subRoot
+from .Utils.Export import sanitize, exportPath
 from .Utils.Tree import pathFS
 
 
@@ -122,7 +122,7 @@ class WNode:
         img = Image.frombytes('RGBA', self.size, img, 'raw', 'BGRA', 0, 1)
         return img
 
-    def save(self):
+    def save(self, dirname=''):
         def toJPEG(img):
             newImg = Image.new('RGBA', img.size, 4 * (255,))
             newImg.alpha_composite(img)
@@ -131,9 +131,10 @@ class WNode:
         img = self.dataToPIL()
         path, ext, margin, scale = (self.meta['d'][0], self.meta['e'],
                                     self.meta['m'][0], self.meta['s'])
-        path and os.makedirs(path, exist_ok=True)
-        path = '{}_{}'.format(osp.join(path, self.name) if path else subRoot(pathFS(self)),
-                              's{s:03d}.{e}')  # yapf: disable
+
+        fullPath = exportPath(path, dirname) if path else exportPath(pathFS(self), dirname)
+        path and os.makedirs(fullPath, exist_ok=True)
+        path = '{}_{}'.format(osp.join(fullPath, self.name) if path else fullPath, 's{s:03d}.{e}')
 
         it = product(ext, scale)
         it = starmap(lambda e, s: (s, e, path.format(e=e, s=s)), it)

--- a/gdquest_art_tools/Infrastructure.py
+++ b/gdquest_art_tools/Infrastructure.py
@@ -1,5 +1,10 @@
-from .Config import config
-from .Utils.Export import subRoot
+from itertools import product, starmap
+import os
+import os.path as osp
+from PIL import Image, ImageOps
+
+from .Utils import kickstart
+from .Utils.Export import sanitize, subRoot
 from .Utils.Tree import pathFS
 
 
@@ -16,23 +21,26 @@ class WNode:
         name = name.split()
         name = filter(lambda n: '=' not in n, name)
         name = '_'.join(name)
-        return name
+        return sanitize(name)
 
     @property
     def meta(self):
+        d = '=', ','
         meta = self.node.name()
+        meta = meta.strip()
         meta = meta.split()
-        meta = filter(lambda m: '=' in m, meta)
+        meta = map(lambda m: m.strip(), meta)
+        meta = filter(lambda m: d[0] in m, meta)
+        meta = map(lambda m: m.split(d[0]), meta)
+        meta = {
+            k: (list(map(lambda s: int(s), v.split(d[1]))) if k in 'sm' else v.split(d[1].lower()))
+            for k, v in meta
+        }  # yapf: disable
+        meta.setdefault('e', ['png'])  # extension
+        meta.setdefault('s', [100])  # scale
+        meta.setdefault('m', [0])  # margin
+        meta.setdefault('d', [''])  # path
         return meta
-
-    @property
-    def extension(self):
-        ext = filter(lambda m: 'e=' in m, self.meta)
-        ext = ''.join(ext)
-        ext = ext.split('=')
-        ext = ext[-1]
-        ext = ext.lower()
-        return ext
 
     @property
     def parent(self):
@@ -57,7 +65,13 @@ class WNode:
         return bounds.width(), bounds.height()
 
     def isExportable(self):
-        return self.extension in config['supportedExtensions']
+        return (self.isPaintLayer()
+                or self.isGroupLayer()
+                or self.isFileLayer()
+                or self.isVectorLayer())  # yapf: disable
+
+    def isMarked(self):
+        return 'e=' in self.node.name()
 
     def isLayer(self):
         return 'layer' in self.type
@@ -101,8 +115,33 @@ class WNode:
     def isColorizeMask(self):
         return self.type == 'colorizemask'
 
-    def save(self):
+    def dataToPIL(self):
         nd = self.node.duplicate()
-        name = subRoot(pathFS(self)), self.extension or 'png'
-        nd.save('.'.join(name), *self.size)
+        nd.setColorSpace('RGBA', 'U8', 'sRGB-elle-V2-srgbtrc')
+        img = nd.projectionPixelData(*self.bounds).data()
+        img = Image.frombytes('RGBA', self.size, img, 'raw', 'BGRA', 0, 1)
+        return img
+
+    def save(self):
+        def toJPEG(img):
+            newImg = Image.new('RGBA', img.size, 4 * (255,))
+            newImg.alpha_composite(img)
+            return newImg.convert('RGB')
+
+        img = self.dataToPIL()
+        path, ext, margin, scale = (self.meta['d'][0], self.meta['e'],
+                                    self.meta['m'][0], self.meta['s'])
+        path and os.makedirs(path, exist_ok=True)
+        path = '{}_{}'.format(osp.join(path, self.name) if path else subRoot(pathFS(self)),
+                              's{s:03d}.{e}')  # yapf: disable
+
+        it = product(ext, scale)
+        it = starmap(lambda e, s: (s, e, path.format(e=e, s=s)), it)
+        it = starmap(lambda s, e, p: ([int(1e-2*wh*s) for wh in self.size], 100 - s != 0, e, p), it)
+        it = starmap(lambda sWH, sDo, e, p: (img.resize(sWH, Image.LANCZOS)
+                                             if sDo else img, e, p), it)
+        it = starmap(lambda i, e, p: (ImageOps.expand(i, margin, (255, 255, 255, 0)), e, p), it)
+        it = starmap(lambda i, e, p: (toJPEG(i) if e in ('jpg', 'jpeg') else i, p), it)
+        it = starmap(lambda i, p: i.save(p), it)
+        kickstart(it)
 

--- a/gdquest_art_tools/Utils/Export.py
+++ b/gdquest_art_tools/Utils/Export.py
@@ -1,6 +1,13 @@
+import os
 import os.path as osp
 import re
+from . import kickstart
+from .Tree import iterDirs
 from ..Config import config
+
+
+def exportPath(path, dirname=''):
+    return osp.join(dirname, subRoot(path))
 
 
 def subRoot(path):
@@ -13,4 +20,12 @@ def sanitize(path):
     ps = map(lambda p: re.sub(config['sym'], '_', p), ps)
     ps = osp.sep.join(ps)
     return ps
+
+
+def makeDirs(node, dirname=''):
+    it = iterDirs(node)
+    it = map(exportPath, it)
+    it = map(lambda d: osp.join(dirname, d), it)
+    it = map(lambda d: os.makedirs(d, exist_ok=True), it)
+    kickstart(it)
 

--- a/gdquest_art_tools/Utils/Export.py
+++ b/gdquest_art_tools/Utils/Export.py
@@ -1,8 +1,5 @@
-import os
 import os.path as osp
 import re
-from . import kickstart
-from .Tree import iterDirs
 from ..Config import config
 
 
@@ -20,12 +17,4 @@ def sanitize(path):
     ps = map(lambda p: re.sub(config['sym'], '_', p), ps)
     ps = osp.sep.join(ps)
     return ps
-
-
-def makeDirs(node, dirname=''):
-    it = iterDirs(node)
-    it = map(exportPath, it)
-    it = map(lambda d: osp.join(dirname, d), it)
-    it = map(lambda d: os.makedirs(d, exist_ok=True), it)
-    kickstart(it)
 

--- a/gdquest_art_tools/Utils/Export.py
+++ b/gdquest_art_tools/Utils/Export.py
@@ -1,9 +1,5 @@
-import os
+import os.path as osp
 import re
-from itertools import chain
-
-from . import kickstart
-from .Tree import iterPre, pathFS
 from ..Config import config
 
 
@@ -12,20 +8,9 @@ def subRoot(path):
     return re.sub(patF, patR, path, count=1)
 
 
-def iterDirs(node):
-    it = iterPre(node)
-    it = filter(lambda n: n.isGroupLayer(), it)
-    it = filter(lambda n:
-                any(i.isExportable()
-                    for i in chain(*map(lambda c: iterPre(c), n.children))),
-                it)
-    it = map(pathFS, it)
-    it = map(subRoot, it)
-    return it
-
-
-def makeDirs(node):
-    it = iterDirs(node)
-    it = map(lambda d: os.makedirs(d, exist_ok=True), it)
-    kickstart(it)
+def sanitize(path):
+    ps = path.split(osp.sep)
+    ps = map(lambda p: re.sub(config['sym'], '_', p), ps)
+    ps = osp.sep.join(ps)
+    return ps
 

--- a/gdquest_art_tools/Utils/Tree.py
+++ b/gdquest_art_tools/Utils/Tree.py
@@ -1,8 +1,5 @@
-import os
 import os.path as osp
 from itertools import chain
-from . import kickstart
-from .Export import subRoot
 
 
 def iterPre(node, maxDepth=-1):
@@ -152,12 +149,5 @@ def iterDirs(node):
     it = filter(lambda n: any(i.isExportable()
                               for i in chain(*map(lambda c: iterPre(c), n.children))), it)
     it = map(pathFS, it)
-    it = map(subRoot, it)
     return it
-
-
-def makeDirs(node):
-    it = iterDirs(node)
-    it = map(lambda d: os.makedirs(d, exist_ok=True), it)
-    kickstart(it)
 

--- a/gdquest_art_tools/Utils/Tree.py
+++ b/gdquest_art_tools/Utils/Tree.py
@@ -1,5 +1,8 @@
+import os
 import os.path as osp
 from itertools import chain
+from . import kickstart
+from .Export import subRoot
 
 
 def iterPre(node, maxDepth=-1):
@@ -16,12 +19,14 @@ def iterPre(node, maxDepth=-1):
     -------
     out: iter(Node)
     """
+
     def go(nodes, depth=0):
         for n in nodes:
             yield n
             # recursively call the generator if depth < maxDepth
             it = go(n.children, depth + 1) if maxDepth == -1 or depth < maxDepth else iter()
             yield from it
+
     return go([node])
 
 
@@ -39,11 +44,13 @@ def iterLevel(node, maxDepth=-1):
     -------
     out: iter(Node)
     """
+
     def go(nodes, depth=0):
         yield from nodes
         it = map(lambda n: go(n.children, depth + 1), nodes)
         it = chain(*it) if maxDepth == -1 or depth < maxDepth else iter()
         yield from it
+
     return go([node])
 
 
@@ -62,11 +69,13 @@ def iterLevelGroup(node, maxDepth=-1):
     out: iter(iter(Node))
     Returns an iterator that holds an iterator for each depth level.
     """
+
     def go(nodes, depth=0):
         yield iter(nodes)
         it = map(lambda n: go(n.children, depth + 1), nodes)
         it = chain(*it) if maxDepth == -1 or depth < maxDepth else iter()
         yield from filter(None, it)
+
     return go([node])
 
 
@@ -84,11 +93,13 @@ def iterPost(node, maxDepth=-1):
     -------
     out: iter(Node)
     """
+
     def go(nodes, depth=0):
         for n in nodes:
             it = go(n.children, depth + 1) if maxDepth == -1 or depth < maxDepth else iter()
             yield from it
             yield n
+
     return go([node])
 
 
@@ -105,10 +116,12 @@ def path(node):
     out: list(Node)
     The path of nodes going through all the parents to the given node.
     """
+
     def go(n, acc=[]):
         acc += [n]
         n.parent and go(n.parent, acc)
         return reversed(acc)
+
     return list(go(node))
 
 
@@ -131,4 +144,20 @@ def pathFS(node):
     it = filter(lambda n: n.parent, path(node))
     it = map(lambda n: n.name, it)
     return osp.join(*it)
+
+
+def iterDirs(node):
+    it = iterPre(node)
+    it = filter(lambda n: n.isGroupLayer(), it)
+    it = filter(lambda n: any(i.isExportable()
+                              for i in chain(*map(lambda c: iterPre(c), n.children))), it)
+    it = map(pathFS, it)
+    it = map(subRoot, it)
+    return it
+
+
+def makeDirs(node):
+    it = iterDirs(node)
+    it = map(lambda d: os.makedirs(d, exist_ok=True), it)
+    kickstart(it)
 

--- a/gdquest_art_tools/Utils/__init__.py
+++ b/gdquest_art_tools/Utils/__init__.py
@@ -1,6 +1,10 @@
 from collections import deque
 
 
+def flip(f):
+    return lambda *a: f(*reversed(a))
+
+
 def kickstart(it):
     deque(it, maxlen=0)
 

--- a/gdquest_art_tools/__init__.py
+++ b/gdquest_art_tools/__init__.py
@@ -1,5 +1,7 @@
+import os.path as osp
+import sys
+sys.path.append(osp.abspath(osp.join(osp.dirname(__file__), 'Dependencies')))
 from .GDquestArtTools import registerDocker  # noqa
-
 
 registerDocker()
 


### PR DESCRIPTION
Metadata in the layer name of the form `LayerName e=png,jpg s=30,100,200 m=10 d=testDir/dir`
where meaning is:
- e: extensions
- s: scale (%)
- m: margin (px) irrespective of given sizes
- d: directory

The above layer would be saved with `LayerName_s030.png`,
`LayerName_s100.png`, `LayerName_s200.png`, `LayerName_s030.jpg`,
`LayerName_s100.jpg`, `LayerName_s200.jpg` filenames under
`testDir/dir` with appropriate scale transformations applied.

Known issues: there's a bug in Krita when accessing pixel data for group
layers and file layers so we need to talk with the devs. and see how to
sort those out before we can export these layers.

Apart from the issue above, the functionality for exporting based on that
metadata is all set, but we most likely have to dig into `multiprocessing`
unless we want to block the UI.

![image](https://user-images.githubusercontent.com/1177508/50289690-40b69080-0472-11e9-9682-371752ebe231.png)

closes #9