### PR TITLE
Implement "basic" layer name/meta management

### DIFF
--- a/gdquest_art_tools/Config.py
+++ b/gdquest_art_tools/Config.py
@@ -1,10 +1,29 @@
 import re
+from collections import OrderedDict
 
-config = {
+
+CONFIG = {
     'outDir': 'export',
     'rootPat': r'^root',
-    'sym': r'\W'
-}  # yapf: disable
-config['rootPat'] = re.compile(config['rootPat'])
-config['sym'] = re.compile(config['sym'])
-
+    'sym': r'\W',
+    'error': {
+        'msg': 'ERROR: {}',
+        'timeout': 8000
+    },
+    'done': {
+        'msg': 'DONE: {}',
+        'timeout': 5000
+    },
+    'delimiters': OrderedDict(
+        (('assign', '='),
+         ('separator', ','))
+    ),  # yapf: disable
+    'meta': {
+        'e': 'png',
+        'm': [0],
+        'p': [''],
+        's': [100]
+    }
+}
+CONFIG['rootPat'] = re.compile(CONFIG['rootPat'])
+CONFIG['sym'] = re.compile(CONFIG['sym'])

--- a/gdquest_art_tools/Utils/Export.py
+++ b/gdquest_art_tools/Utils/Export.py
@@ -1,20 +1,19 @@
 import os.path as osp
 import re
-from ..Config import config
+from ..Config import CONFIG
 
 
-def exportPath(path, dirname=''):
-    return osp.join(dirname, subRoot(path))
+def exportPath(cfg, path, dirname=''):
+    return osp.join(dirname, subRoot(cfg, path))
 
 
-def subRoot(path):
-    patF, patR = config['rootPat'], config['outDir']
+def subRoot(cfg, path):
+    patF, patR = cfg['rootPat'], CONFIG['outDir']
     return re.sub(patF, patR, path, count=1)
 
 
 def sanitize(path):
     ps = path.split(osp.sep)
-    ps = map(lambda p: re.sub(config['sym'], '_', p), ps)
+    ps = map(lambda p: re.sub(CONFIG['sym'], '_', p), ps)
     ps = osp.sep.join(ps)
     return ps
-


### PR DESCRIPTION
It works like this. There are reserved "meta" defining characters: `emps`:

- `e`: extension - `e=jpg,png`
- `m`: margin - `m=10,30,50` in pixels
- `s`: size - `s=30,20,100,150` in percentage
- `p`: path - `p=custom/path`, if `p` is used the plugin will export in the given (absolute or relative) path instead of `exports`

The layer name management works by typing in the text field modifications to be made to it (multiple selected layers are supported of course). Examples will show better. Say we have this Krita document structure:

```
root
+-- RobiCharacter s=20,30 *
    +-- RobiArm e=jpg *
    +-- RobiTorso p=testExportDir *
+-- Background
```

where `*` means these layers are selected. We then can do some stuff with the plugin - if we write `e=png s=20,100 Robi=Godette p=` in the text box, the new layer names will be:

```
root
+-- GodetteCharacter e=png s=20,100 *
    +-- GodetteArm e=png s=20,100 *
    +-- GodetteTorso e=png s=20,100 *
+-- Background
```

So we can see a number of things happening, notably `this=that` replaces `this` with `that` IF `this` isn't one of the reserved meta characters: `emps`. `this=` means delete `this` (replace with nothing), while the rest are either replacements or additions. For example `RobiArm` already had `e=jpg` so it's replaced with `e=png` while `RobiTorso` didn't have `e=png` so it's added.

That is all.