### PR TITLE
Initial COA Tools export support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,8 @@ Get started with the add-on and the batch export tools: https://youtu.be/jJE5iqE
 Updated the plugin's built-in documentation. See [Manual.md](https://github.com/GDquest/GDquest-art-tools/blob/master/gdquest_art_tools/Manual.md)
 
 ### 🎥🕺 New features ###
-
+- **COA Tools export** basic support for exporting to coa_tools
+  - Export multiple layers to [coa_tools](https://github.com/ndee85/coa_tools) format
 - **Batch export all layers in the background** based on metadata in their name
   - Scale images on export
   - Add an empty margin to images

--- a/gdquest_art_tools/COATools.py
+++ b/gdquest_art_tools/COATools.py
@@ -1,0 +1,91 @@
+import os
+import json
+
+from functools import partial
+from .Infrastructure import WNode
+from .Utils import kickstart, flip
+from .Utils.Tree import iterPre
+
+from krita import Krita
+from PIL import Image, ImageOps
+
+KI = Krita.instance()
+
+class COAToolsFormat:
+    def __init__(self, cfg, statusBar):
+        self.cfg = cfg
+        self.statusBar = statusBar
+        self.reset()
+
+    def reset(self):
+        self.nodes = []
+
+    def showError(self, msg):
+        msg, timeout = self.cfg['error']['msg'].format(msg), cfg['error']['timeout']
+        self.statusBar.showMessage(msg, timeout)
+
+    def collect(self, node):
+        print("COAToolsFormat collecting %s" % ( node.name ) )
+        self.nodes.append(node)
+
+    def remap(self, oldValue, oldMin, oldMax, newMin, newMax):
+        if oldMin == newMin and oldMax == newMax:
+            return oldValue;
+        return (((oldValue - oldMin) * (newMax - newMin)) / (oldMax - oldMin)) + newMin;
+
+    def save(self, output_dir=''):
+        # For each top-level node (Group Layer)
+        cfg = self.cfg
+        for wn in self.nodes:
+            knode = wn.node
+            meta = wn.meta
+            children = wn.children
+
+            os.makedirs(output_dir, exist_ok=True)
+            print("COAToolsFormat exporting %d items from %s" % ( len(children), wn.name ) )
+
+            # TODO handle c=sheet cases and generate multi-sprite bitmaps for 'switch layers' as the GIMP exporter does
+
+            try:
+                if len(children) <= 0:
+                    raise ValueError(wn.name,'has no children to export')
+
+                coa_data = { 'name': wn.name, 'nodes': [] }
+                print("COAToolsFormat exporting %s meta: (%s) to %s" % ( wn.name, meta['c'], output_dir ) )
+                for idx, child in enumerate(children):
+                    fn = child.save(output_dir)
+
+                    node = child.node
+                    coords = node.bounds().getCoords()
+                    relative_coords = coords
+
+                    parent_node = node.parentNode()
+                    parent_coords = parent_node.bounds().getCoords()
+                    relative_coords = [coords[0]-parent_coords[0],coords[1]-parent_coords[1]]
+
+                    p_width = parent_coords[2]-parent_coords[0]
+                    p_height = parent_coords[3]-parent_coords[1]
+                    coa_entry = {
+                        "children": [],
+                        "frame_index": 0,
+                        "name": child.name,
+                        "node_path": child.name,
+                        "offset": [ -p_width/2, p_height/2 ],
+                        "opacity": self.remap(node.opacity(),0,255,0,1),
+                        "pivot_offset": [ 0.0, 0.0 ],
+                        "position": relative_coords,
+                        "resource_path": fn.replace(output_dir+os.path.sep+cfg['outDir']+os.path.sep,''),
+                        "rotation": 0.0,
+                        "scale": [ 1.0, 1.0 ],
+                        "tiles_x": 1,
+                        "tiles_y": 1,
+                        "type": "SPRITE",
+                        "z": idx-len(children)+1
+                        }
+                    coa_data['nodes'].append(coa_entry)
+
+                json_data = json.dumps(coa_data, sort_keys=True, indent=4, separators=(',', ': '))
+                with open(output_dir+os.path.sep+cfg['outDir']+os.path.sep+wn.name+".json", "w") as fh:
+                    fh.write(json_data)
+            except ValueError as e:
+                showError(e)

--- a/gdquest_art_tools/COATools.py
+++ b/gdquest_art_tools/COATools.py
@@ -34,11 +34,15 @@ class COAToolsFormat:
     def save(self, output_dir=''):
         # For each top-level node (Group Layer)
         cfg = self.cfg
+        export_dir = output_dir
         for wn in self.nodes:
             meta = wn.meta
             children = wn.children
+            path = wn.path
 
-            os.makedirs(output_dir, exist_ok=True)
+            if path != '':
+                export_dir = path
+
             print("COAToolsFormat exporting %d items from %s" % ( len(children), wn.name ) )
 
             # TODO handle c=sheet cases from `meta['c']` and generate multi-sprite bitmaps for 'switch layers' as the GIMP exporter does
@@ -50,9 +54,9 @@ class COAToolsFormat:
                     raise ValueError(wn.name,'has no children to export')
 
                 coa_data = { 'name': wn.name, 'nodes': [] }
-                print("COAToolsFormat exporting %s meta: (%s) to %s" % ( wn.name, meta['c'], output_dir ) )
+                print("COAToolsFormat exporting %s meta: (%s) to %s" % ( wn.name, meta['c'], export_dir ) )
                 for idx, child in enumerate(children):
-                    fn = child.save(output_dir)
+                    fn = child.save(export_dir)
 
                     node = child.node
                     coords = node.bounds().getCoords()
@@ -73,7 +77,7 @@ class COAToolsFormat:
                         "opacity": self.remap(node.opacity(),0,255,0,1),
                         "pivot_offset": [ 0.0, 0.0 ],
                         "position": relative_coords,
-                        "resource_path": fn.replace(output_dir+os.path.sep+cfg['outDir']+os.path.sep,''),
+                        "resource_path": fn.replace(export_dir+os.path.sep+cfg['outDir']+os.path.sep,''),
                         "rotation": 0.0,
                         "scale": [ 1.0, 1.0 ],
                         "tiles_x": 1,
@@ -84,7 +88,7 @@ class COAToolsFormat:
                     coa_data['nodes'].append(coa_entry)
 
                 json_data = json.dumps(coa_data, sort_keys=True, indent=4, separators=(',', ': '))
-                with open(output_dir+os.path.sep+cfg['outDir']+os.path.sep+wn.name+".json", "w") as fh:
+                with open(export_dir+os.path.sep+cfg['outDir']+os.path.sep+wn.name+".json", "w") as fh:
                     fh.write(json_data)
             except ValueError as e:
                 showError(e)

--- a/gdquest_art_tools/COATools.py
+++ b/gdquest_art_tools/COATools.py
@@ -9,8 +9,6 @@ from .Utils.Tree import iterPre
 from krita import Krita
 from PIL import Image, ImageOps
 
-KI = Krita.instance()
-
 class COAToolsFormat:
     def __init__(self, cfg, statusBar):
         self.cfg = cfg
@@ -37,14 +35,15 @@ class COAToolsFormat:
         # For each top-level node (Group Layer)
         cfg = self.cfg
         for wn in self.nodes:
-            knode = wn.node
             meta = wn.meta
             children = wn.children
 
             os.makedirs(output_dir, exist_ok=True)
             print("COAToolsFormat exporting %d items from %s" % ( len(children), wn.name ) )
 
-            # TODO handle c=sheet cases and generate multi-sprite bitmaps for 'switch layers' as the GIMP exporter does
+            # TODO handle c=sheet cases from `meta['c']` and generate multi-sprite bitmaps for 'switch layers' as the GIMP exporter does
+            # if meta['c'] == "sheet":
+            #   self.generateSpritesheet(wn)
 
             try:
                 if len(children) <= 0:

--- a/gdquest_art_tools/Config.py
+++ b/gdquest_art_tools/Config.py
@@ -19,6 +19,7 @@ CONFIG = {
          ('separator', ','))
     ),  # yapf: disable
     'meta': {
+        'c': [''],
         'e': ['png'],
         'm': [0],
         'p': [''],

--- a/gdquest_art_tools/GDquestArtTools.py
+++ b/gdquest_art_tools/GDquestArtTools.py
@@ -76,17 +76,13 @@ def exportCOATools(mode, cfg, statusBar):
         dirName = osp.dirname(doc.fileName())
         nodes = KI.activeWindow().activeView().selectedNodes()
 
-        # If no nodes are selected, use document root
+        # If mode is document or no nodes are selected, use document root
         if mode == "document" or len(nodes) == 0:
             nodes = [doc.rootNode()]
 
-        # By convention all selected nodes should be Group Layers
-        for n in nodes:
-            wn = WNode(cfg, n)
-            if not wn.isGroupLayer():
-                raise ValueError(wn.name,'is not a Group Layer')
-
         it = map(partial(WNode, cfg), nodes)
+        # By convention all selected nodes should be Group Layers
+        it = filter(lambda n: n.isGroupLayer(), it)
         it = map(coat_format.collect, it)
         kickstart(it)
         coat_format.save(dirName)

--- a/gdquest_art_tools/Infrastructure.py
+++ b/gdquest_art_tools/Infrastructure.py
@@ -39,7 +39,7 @@ class WNode:
         meta = filter(lambda m: m[0] in self.cfg['meta'].keys(), meta)
         meta = OrderedDict((k, v.lower().split(s)) for k, v in meta)
         meta.update({k: map(int, v) for k, v in meta.items() if k in 'ms'})
-        meta.setdefault('c', self.cfg['meta']['c']) # coa_tools
+        meta.setdefault('c', self.cfg['meta']['c'])  # coa_tools
         meta.setdefault('e', self.cfg['meta']['e'])  # extension
         meta.setdefault('m', self.cfg['meta']['m'])  # margin
         meta.setdefault('p', self.cfg['meta']['p'])  # path

--- a/gdquest_art_tools/Infrastructure.py
+++ b/gdquest_art_tools/Infrastructure.py
@@ -39,6 +39,7 @@ class WNode:
         meta = filter(lambda m: m[0] in self.cfg['meta'].keys(), meta)
         meta = OrderedDict((k, v.lower().split(s)) for k, v in meta)
         meta.update({k: map(int, v) for k, v in meta.items() if k in 'ms'})
+        meta.setdefault('c', self.cfg['meta']['c']) # coa_tools
         meta.setdefault('e', self.cfg['meta']['e'])  # extension
         meta.setdefault('m', self.cfg['meta']['m'])  # margin
         meta.setdefault('p', self.cfg['meta']['p'])  # path
@@ -189,3 +190,5 @@ class WNode:
         it = starmap(lambda i, e, p: (toJPEG(i) if e in ('jpg', 'jpeg') else i, p), it)
         it = starmap(lambda i, p: i.save(p), it)
         kickstart(it)
+
+        return path.format(e=ext[0], m=margin[0], s=scale[0])

--- a/gdquest_art_tools/Manual.md
+++ b/gdquest_art_tools/Manual.md
@@ -86,3 +86,10 @@ erase the text you searched for.
 The rename tool is smarter with meta tags. Writing `e=` will remove the
 extension tag entirely. For example, `Godete e=png s=50,100` will become
 `Godette s=50,100`.
+
+## COA Tools format
+
+You can select multiple group layers anywhere in the document and export their
+contents and generate the necessary metadata file for easy import in
+COA Tools / Blender. Right now the exporter is not able to generate
+spritesheets for use with switching e.g. mouth states.

--- a/gdquest_art_tools/Manual.md
+++ b/gdquest_art_tools/Manual.md
@@ -89,7 +89,36 @@ extension tag entirely. For example, `Godete e=png s=50,100` will become
 
 ## COA Tools format
 
-You can select multiple group layers anywhere in the document and export their
-contents and generate the necessary metadata file for easy import in
-COA Tools / Blender. Right now the exporter is not able to generate
+The exporter will generate the necessary sprite contents and metadata file for
+easy import in COA Tools / Blender.
+
+Right now the exporter is *not* able to generate
 spritesheets for use with switching e.g. mouth states.
+
+If you want to export your krita document to COA Tools format,
+simply have no layers selected and click the `As COA Tools` button.
+
+If you want to export multiple COA Tool documents from one Krita document
+(if you have e.g. multiple characters in one Krita document),
+you can do so by selecting a Group Layer to serve as root for each COA Tool export
+you want done.
+
+### Example
+You want to export two characters from the same Krita document in one go
+```
+Root
+  +-- Robot (Group Layer)       <-- Select this layer
+  |    +-- Head
+  |    +-- Body
+  |    +-- Legs
+  |
+  +-- Sketches
+  |    +-- ...
+  |
+  +-- Minion (Group Layer)      <-- ... and this layer
+  |    +-- Hat
+  |    +-- Head
+  |
+  Background
+```
+Once the Group Layers are selected you push "As COA Tools".

--- a/gdquest_art_tools/Manual.md
+++ b/gdquest_art_tools/Manual.md
@@ -96,7 +96,7 @@ Right now the exporter is *not* able to generate
 spritesheets for use with switching e.g. mouth states.
 
 If you want to export your krita document to COA Tools format,
-simply have no layers selected and click the `As COA Tools` button.
+simply have no layers selected and click the `Document` button under COA Tools.
 
 If you want to export multiple COA Tool documents from one Krita document
 (if you have e.g. multiple characters in one Krita document),


### PR DESCRIPTION
As the title says. I hope you can use it :)

I haven't looked at the sprite-sheet feature found in [the GIMP version](https://github.com/ndee85/coa_tools/tree/master/GIMP) yet.

I need a little more time to investigate what's being done.
The cool thing is, though, that it can export multiple Group Layers at once :)
![image](https://user-images.githubusercontent.com/768942/53773907-9258ae00-3eec-11e9-8d1c-8b05cc9a5d30.png)

Here's a shot from my reference / test file:
![image](https://user-images.githubusercontent.com/768942/53773747-eca53f00-3eeb-11e9-9f79-9ed9ccc51a86.png)

Imported in Blender:
![image](https://user-images.githubusercontent.com/768942/53773723-cf707080-3eeb-11e9-97d0-bb97d17f6cfa.png)
