### PR TITLE
Fix export

### DIFF
--- a/gdquest_art_tools/COATools.py
+++ b/gdquest_art_tools/COATools.py
@@ -56,7 +56,7 @@ class COAToolsFormat:
                 coa_data = { 'name': wn.name, 'nodes': [] }
                 print("COAToolsFormat exporting %s meta: (%s) to %s" % ( wn.name, meta['c'], export_dir ) )
                 for idx, child in enumerate(children):
-                    fn = child.save(export_dir)
+                    fn = child.saveCOA(export_dir)
 
                     node = child.node
                     coords = node.bounds().getCoords()
@@ -90,5 +90,6 @@ class COAToolsFormat:
                 json_data = json.dumps(coa_data, sort_keys=True, indent=4, separators=(',', ': '))
                 with open(export_dir+os.path.sep+cfg['outDir']+os.path.sep+wn.name+".json", "w") as fh:
                     fh.write(json_data)
+
             except ValueError as e:
                 showError(e)

--- a/gdquest_art_tools/GDquestArtTools.py
+++ b/gdquest_art_tools/GDquestArtTools.py
@@ -82,10 +82,12 @@ def exportCOATools(mode, cfg, statusBar):
 
         it = map(partial(WNode, cfg), nodes)
         # By convention all selected nodes should be Group Layers
+        # This is to represent a logical root for each export in COATools format
         it = filter(lambda n: n.isGroupLayer(), it)
         it = map(coat_format.collect, it)
         kickstart(it)
         coat_format.save(dirName)
+
     except ValueError as e:
         msg, timeout = cfg['error']['msg'].format(e), cfg['error']['timeout']
     statusBar.showMessage(msg, timeout)

--- a/gdquest_art_tools/Infrastructure.py
+++ b/gdquest_art_tools/Infrastructure.py
@@ -191,4 +191,13 @@ class WNode:
         it = starmap(lambda i, p: i.save(p), it)
         kickstart(it)
 
+        ext = list(ext) if ext else []
+        if len(ext) == 0:
+            ext.append(self.cfg['meta']['e'][0])
+        margin = list(margin) if margin else []
+        if len(margin) == 0:
+            margin.append(self.cfg['meta']['m'][0])
+        scale = list(scale) if scale else []
+        if len(scale) == 0:
+            scale.append(self.cfg['meta']['s'][0])
         return path.format(e=ext[0], m=margin[0], s=scale[0])

--- a/gdquest_art_tools/Infrastructure.py
+++ b/gdquest_art_tools/Infrastructure.py
@@ -38,7 +38,7 @@ class WNode:
         meta = starmap(lambda fst, snd: (fst[-1], snd.split()[0]), zip(meta[:-1], meta[1:]))
         meta = filter(lambda m: m[0] in self.cfg['meta'].keys(), meta)
         meta = OrderedDict((k, v.lower().split(s)) for k, v in meta)
-        meta.update({k: map(int, v) for k, v in meta.items() if k in 'ms'})
+        meta.update({k: list(map(int, v)) for k, v in meta.items() if k in 'ms'})
         meta.setdefault('c', self.cfg['meta']['c'])  # coa_tools
         meta.setdefault('e', self.cfg['meta']['e'])  # extension
         meta.setdefault('m', self.cfg['meta']['m'])  # margin
@@ -191,13 +191,34 @@ class WNode:
         it = starmap(lambda i, p: i.save(p), it)
         kickstart(it)
 
-        ext = list(ext) if ext else []
-        if len(ext) == 0:
-            ext.append(self.cfg['meta']['e'][0])
-        margin = list(margin) if margin else []
-        if len(margin) == 0:
-            margin.append(self.cfg['meta']['m'][0])
-        scale = list(scale) if scale else []
-        if len(scale) == 0:
-            scale.append(self.cfg['meta']['s'][0])
-        return path.format(e=ext[0], m=margin[0], s=scale[0])
+
+    def saveCOA(self, dirname=''):
+        def dataToPIL():
+            img = self.node.projectionPixelData(*self.bounds).data()
+            img = Image.frombytes('RGBA', self.size, img, 'raw', 'BGRA', 0, 1)
+            return img
+
+        def toJPEG(img):
+            newImg = Image.new('RGBA', img.size, 4*(255, ))
+            newImg.alpha_composite(img)
+            return newImg.convert('RGB')
+
+        img = dataToPIL()
+        meta = self.meta
+        path, ext = '', meta['e']
+
+        dirPath = (
+            exportPath(self.cfg,
+                       path,
+                       dirname) if path else exportPath(self.cfg,
+                                                        pathFS(self.parent),
+                                                        dirname)
+        )
+        os.makedirs(dirPath, exist_ok=True)
+        path = '{}{}'.format(osp.join(dirPath, self.name), '.{e}')
+        path = path.format(e=ext[0])
+        if ext in ('jpg', 'jpeg'):
+            toJPEG(img)
+        img.save(path)
+
+        return path

--- a/gdquest_art_tools/Manual.md
+++ b/gdquest_art_tools/Manual.md
@@ -121,4 +121,11 @@ Root
   |
   Background
 ```
-Once the Group Layers are selected you push "As COA Tools".
+Once the Group Layers are selected you push "COA Tools -> Selected Layers".
+
+Each export root supports the following metadata:
+- `[p=path/to/custom/export/directory]` - custom output path.
+    Paths can be absolute or relative to the Krita document.
+
+Each child node of an export root supports the following metadata:
+- `[e=jpg,png]` - supported export image extensions


### PR DESCRIPTION
Introduced dedicated `saveCOA` on `WNode` to incapsulate the specific behaviour needed when exporting to COA Tools format. 
