### PR TITLE
Add fullscreen export option

### DIFF
--- a/batch_exporter/Config.py
+++ b/batch_exporter/Config.py
@@ -9,7 +9,7 @@ CONFIG = {
     "error": {"msg": "ERROR: {}", "timeout": 8000},
     "done": {"msg": "DONE: {}", "timeout": 5000},
     "delimiters": OrderedDict((("assign", "="), ("separator", ","))),  # yapf: disable
-    "meta": {"c": [""], "e": ["png"], "m": [0], "p": [""], "f": False, "s": [100]},
+    "meta": {"c": [""], "e": ["png"], "m": [0], "p": [""], "t": [""], "s": [100]},
 }
 CONFIG["rootPat"] = re.compile(CONFIG["rootPat"])
 CONFIG["sym"] = re.compile(CONFIG["sym"])

--- a/batch_exporter/Config.py
+++ b/batch_exporter/Config.py
@@ -9,7 +9,7 @@ CONFIG = {
     "error": {"msg": "ERROR: {}", "timeout": 8000},
     "done": {"msg": "DONE: {}", "timeout": 5000},
     "delimiters": OrderedDict((("assign", "="), ("separator", ","))),  # yapf: disable
-    "meta": {"c": [""], "e": ["png"], "m": [0], "p": [""], "s": [100]},
+    "meta": {"c": [""], "e": ["png"], "m": [0], "p": [""], "f": False, "s": [100]},
 }
 CONFIG["rootPat"] = re.compile(CONFIG["rootPat"])
 CONFIG["sym"] = re.compile(CONFIG["sym"])

--- a/batch_exporter/Infrastructure.py
+++ b/batch_exporter/Infrastructure.py
@@ -20,7 +20,7 @@ def nodeToImage(wnode):
     Returns an QImage 8-bit sRGB
     """
     SRGB_PROFILE = "sRGB-elle-V2-srgbtrc.icc"
-    if wnode.fullscreen:
+    if wnode.trim == False:
         bounds = KI.activeDocument().bounds()
         x = bounds.x()
         y = bounds.y()
@@ -95,12 +95,12 @@ class WNode:
         meta = filter(lambda m: m[0] in self.cfg["meta"].keys(), meta)
         meta = OrderedDict((k, v.lower().split(s)) for k, v in meta)
         meta.update({k: list(map(int, v)) for k, v in meta.items() if k in "ms"})
-        meta["f"] = ("f" in meta)                    # full-screen export
         meta.setdefault("c", self.cfg["meta"]["c"])  # coa_tools
         meta.setdefault("e", self.cfg["meta"]["e"])  # extension
         meta.setdefault("m", self.cfg["meta"]["m"])  # margin
         meta.setdefault("p", self.cfg["meta"]["p"])  # path
         meta.setdefault("s", self.cfg["meta"]["s"])  # scale
+        meta.setdefault("t", self.cfg["meta"]["t"])  # trim
         return meta
 
     @property
@@ -112,8 +112,11 @@ class WNode:
         return self.meta["c"][0]
 
     @property
-    def fullscreen(self):
-        return self.meta["f"]
+    def trim(self):
+        if self.meta["t"] == ["false"]:
+            return False
+        else:
+            return self.meta["t"]
 
     @property
     def parent(self):

--- a/batch_exporter/Infrastructure.py
+++ b/batch_exporter/Infrastructure.py
@@ -20,7 +20,14 @@ def nodeToImage(wnode):
     Returns an QImage 8-bit sRGB
     """
     SRGB_PROFILE = "sRGB-elle-V2-srgbtrc.icc"
-    [x, y, w, h] = wnode.bounds
+    if wnode.fullscreen:
+        bounds = KI.activeDocument().bounds()
+        x = bounds.x()
+        y = bounds.y()
+        w = bounds.width()
+        h = bounds.height()
+    else:
+        [x, y, w, h] = wnode.bounds
 
     is_srgb = (
         wnode.node.colorModel() == "RGBA"
@@ -88,6 +95,7 @@ class WNode:
         meta = filter(lambda m: m[0] in self.cfg["meta"].keys(), meta)
         meta = OrderedDict((k, v.lower().split(s)) for k, v in meta)
         meta.update({k: list(map(int, v)) for k, v in meta.items() if k in "ms"})
+        meta["f"] = ("f" in meta)                    # full-screen export
         meta.setdefault("c", self.cfg["meta"]["c"])  # coa_tools
         meta.setdefault("e", self.cfg["meta"]["e"])  # extension
         meta.setdefault("m", self.cfg["meta"]["m"])  # margin
@@ -102,6 +110,10 @@ class WNode:
     @property
     def coa(self):
         return self.meta["c"][0]
+
+    @property
+    def fullscreen(self):
+        return self.meta["f"]
 
     @property
     def parent(self):

--- a/batch_exporter/Manual.md
+++ b/batch_exporter/Manual.md
@@ -19,8 +19,8 @@ the layer name. The supported options are:
 - `[m=20,30,100]` - extra margin in `px`. The layer is trimmed to the
   smallest bounding box by default. This option adds extra padding around the
   layer.
-- `[f=1]` - export the layer without cropping the layer image to its
-  bounding box.
+- `[t=false]` - disable trimming the exported layer to the bounding box of
+  the content.
 
 A typical layer name with metadata looks like: `CharacterTorso e=png m=30
 s=50,100`. This exports the layer as two images, with an added padding of 30 pixels

--- a/batch_exporter/Manual.md
+++ b/batch_exporter/Manual.md
@@ -19,6 +19,8 @@ the layer name. The supported options are:
 - `[m=20,30,100]` - extra margin in `px`. The layer is trimmed to the
   smallest bounding box by default. This option adds extra padding around the
   layer.
+- `[f=1]` - export the layer without cropping the layer image to its
+  bounding box.
 
 A typical layer name with metadata looks like: `CharacterTorso e=png m=30
 s=50,100`. This exports the layer as two images, with an added padding of 30 pixels


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [X] The commit message follows our guidelines.
- For bug fixes and features:
    - [X] You tested the changes.
    - [X] You updated the docs or changelog.

**What kind of change does this PR introduce?**

I needed fullscreen export for Synfig and mouth lipsync, since image imports in Synfig require a lot of manual tweaking that I wanted to avoid.

**Does this PR introduce a breaking change?**

Not as far as I know.

## New feature or change ##

**What is the current behavior?** 

All images are exported cropped to the layer's computed bounding box.

**What is the new behavior?**

A layer with `f=1` is exported to the size of the document's bounding box rather than the layer's.

**Other information**
